### PR TITLE
Add Ourlads depth chart scraping utility

### DIFF
--- a/pybaseball/__init__.py
+++ b/pybaseball/__init__.py
@@ -100,5 +100,6 @@ from .plotting import plot_teams
 from .plotting import plot_strike_zone
 from .datasources.fangraphs import (fg_batting_data, fg_pitching_data, fg_team_batting_data, fg_team_fielding_data,
                                     fg_team_pitching_data)
+from .datasources.ourlads import read_starters_ourlads
 from .split_stats import get_splits
 from .version import __version__

--- a/pybaseball/datasources/ourlads.py
+++ b/pybaseball/datasources/ourlads.py
@@ -1,0 +1,188 @@
+"""Utilities for scraping Ourlads NFL depth chart data."""
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+import re
+from typing import Iterable, Optional
+
+import pandas as pd
+import requests
+
+
+_COLUMNS = ["team", "position", "player", "status"]
+_PLAYER_COLUMN_PATTERN = re.compile(r"^(?:No\s*)?Player", re.IGNORECASE)
+
+
+def _ourlads_url(team: str) -> str:
+    return f"https://www.ourlads.com/nfldepthcharts/pfdepthchart/{team}"
+
+
+def _empty_result() -> pd.DataFrame:
+    return pd.DataFrame(columns=_COLUMNS)
+
+
+def _flatten_columns(columns: pd.Index) -> list[str]:
+    flattened: list[str] = []
+    for col in columns:
+        if isinstance(col, tuple):
+            parts = [
+                str(part).strip()
+                for part in col
+                if str(part).strip() not in {"", "nan"} and not str(part).startswith("Unnamed:")
+            ]
+            flat = " ".join(parts).strip()
+        else:
+            flat = str(col).strip()
+        flattened.append(flat)
+    return flattened
+
+
+def _clean_name(raw: str) -> str:
+    cleaned = re.sub(r"\s*\d+\w*$", "", raw)
+    cleaned = re.sub(r"\s*\(.*?\)", "", cleaned)
+    cleaned = cleaned.strip()
+    if "," in cleaned:
+        parts = [part.strip() for part in cleaned.split(",", 1)]
+        if len(parts) == 2:
+            cleaned = f"{parts[1]} {parts[0]}".strip()
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned
+
+
+def _map_pos(row_pos: str, slot_idx: Optional[int]) -> Optional[str]:
+    if slot_idx is None:
+        return None
+    row_pos = row_pos.upper()
+    if row_pos in {"QB", "RB", "FB", "TE"}:
+        if row_pos == "RB":
+            return "RB1" if slot_idx == 1 else "RB2"
+        if row_pos == "TE":
+            return "TE1" if slot_idx == 1 else "TE2"
+        return row_pos
+    if row_pos in {"WR", "LWR", "RWR", "SWR", "WR-SLOT", "SLOT"}:
+        if row_pos in {"SWR", "WR-SLOT", "SLOT"}:
+            return "SLOT" if slot_idx == 1 else None
+        lookup = ["WR1", "WR2", "WR3", "WR4", "WR5"]
+        if 1 <= slot_idx <= len(lookup):
+            return lookup[slot_idx - 1]
+    return None
+
+
+def ourlads_scrape_team(team: str) -> pd.DataFrame:
+    """Scrape the Ourlads depth chart for a single team."""
+    url = _ourlads_url(team)
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException:
+        return _empty_result()
+
+    try:
+        tables = pd.read_html(StringIO(response.text))
+    except ValueError:
+        return _empty_result()
+
+    if not tables:
+        return _empty_result()
+
+    df = tables[0].copy()
+    if df.empty:
+        return _empty_result()
+
+    df.columns = _flatten_columns(df.columns)
+    if df.columns.empty:
+        return _empty_result()
+    df.rename(columns={df.columns[0]: "Pos"}, inplace=True)
+
+    keep_cols = ["Pos"] + [col for col in df.columns[1:] if _PLAYER_COLUMN_PATTERN.match(col)]
+    if len(keep_cols) <= 1:
+        return _empty_result()
+    df = df[keep_cols]
+    df["Pos"] = df["Pos"].astype(str).str.strip()
+
+    positions = df["Pos"].fillna("")
+    upper_positions = positions.str.upper()
+
+    offense_mask = upper_positions.eq("OFFENSE")
+    defense_mask = upper_positions.eq("DEFENSE")
+
+    if offense_mask.any():
+        start_idx = offense_mask[offense_mask].index[0]
+        if defense_mask.any():
+            end_idx = defense_mask[defense_mask].index[0]
+        else:
+            end_idx = df.index[-1] + 1
+        offense_df = df.loc[start_idx + 1 : end_idx - 1]
+    else:
+        if defense_mask.any():
+            end_idx = defense_mask[defense_mask].index[0]
+            offense_df = df.loc[: end_idx - 1]
+        else:
+            offense_df = df
+
+    offense_df = offense_df[offense_df["Pos"].astype(str).str.strip().ne("")]
+    offense_df = offense_df[~offense_df["Pos"].str.contains("Offense|Defense|Special", case=False, na=False)]
+    if offense_df.empty:
+        return _empty_result()
+
+    player_columns = [col for col in offense_df.columns if col != "Pos"]
+    slot_order = {col: idx + 1 for idx, col in enumerate(player_columns)}
+
+    long_df = offense_df.melt(id_vars="Pos", var_name="slot", value_name="raw", ignore_index=False)
+    long_df.dropna(subset=["raw"], inplace=True)
+    long_df["raw"] = long_df["raw"].astype(str).str.strip()
+    long_df = long_df[long_df["raw"].ne("")]
+    if long_df.empty:
+        return _empty_result()
+
+    long_df["player"] = long_df["raw"].apply(_clean_name)
+    long_df["slot_id"] = long_df["slot"].map(slot_order)
+    long_df["position"] = long_df.apply(lambda row: _map_pos(row["Pos"], row["slot_id"]), axis=1)
+    long_df.dropna(subset=["position"], inplace=True)
+    if long_df.empty:
+        return _empty_result()
+
+    long_df["team"] = team
+    long_df["status"] = "ACT"
+    result = long_df.drop_duplicates(subset=["position", "player"], keep="first")
+    return result[["team", "position", "player", "status"]].reset_index(drop=True)
+
+
+def read_starters_ourlads(
+    teams: Iterable[str], *, override_path: Optional[str | Path] = Path("starters_override.csv")
+) -> pd.DataFrame:
+    """Read starters for a collection of teams from Ourlads."""
+    frames = [ourlads_scrape_team(team) for team in teams]
+    if frames:
+        out = pd.concat(frames, ignore_index=True)
+    else:
+        out = _empty_result()
+
+    if out.empty:
+        out = _empty_result()
+
+    if override_path is not None:
+        path = Path(override_path)
+        if path.exists():
+            overrides = pd.read_csv(path)
+            if overrides.empty:
+                return out
+            overrides = overrides.copy()
+            if "status" not in overrides.columns:
+                overrides["status"] = "ACT"
+            overrides = overrides[[col for col in _COLUMNS if col in overrides.columns]]
+            for column in _COLUMNS:
+                if column not in overrides.columns:
+                    overrides[column] = "" if column != "status" else "ACT"
+            overrides = overrides[_COLUMNS]
+
+            if not out.empty:
+                keys = overrides[["team", "position"]].drop_duplicates()
+                out = out.merge(keys, on=["team", "position"], how="left", indicator=True)
+                out = out[out["_merge"] == "left_only"].drop(columns="_merge")
+            if out.empty:
+                out = overrides.copy()
+            else:
+                out = pd.concat([out, overrides], ignore_index=True)
+    return out.reset_index(drop=True)

--- a/tests/pybaseball/datasources/test_ourlads.py
+++ b/tests/pybaseball/datasources/test_ourlads.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+import pandas as pd
+import pytest
+import requests
+
+from pybaseball.datasources import ourlads
+
+
+class DummyResponse:
+    def __init__(self, text: str, status_code: int = 200) -> None:
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if not (200 <= self.status_code < 300):
+            raise requests.HTTPError(f"status code: {self.status_code}")
+
+
+def fake_get_factory(html: str):
+    def _fake_get(url: str, timeout: int = 30) -> DummyResponse:  # pragma: no cover - simple wrapper
+        return DummyResponse(html)
+
+    return _fake_get
+
+
+SAMPLE_HTML = """
+<table>
+    <thead>
+        <tr>
+            <th>Pos</th>
+            <th>No</th>
+            <th>No</th>
+            <th>No</th>
+        </tr>
+        <tr>
+            <th></th>
+            <th>Player 1</th>
+            <th>Player 2</th>
+            <th>Player 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td>Offense</td><td></td><td></td><td></td></tr>
+        <tr><td>QB</td><td>Allen, Josh 26S</td><td></td><td></td></tr>
+        <tr><td>RB</td><td>Cook, James</td><td>Murray, Latavius 28</td><td></td></tr>
+        <tr><td>WR</td><td>Diggs, Stefon 26S</td><td>Davis, Gabriel</td><td>Shakir, Khalil</td></tr>
+        <tr><td>SWR</td><td>Beasley, Cole</td><td></td><td></td></tr>
+        <tr><td>Defense</td><td></td><td></td><td></td></tr>
+    </tbody>
+</table>
+"""
+
+
+def test_read_starters_ourlads(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ourlads.requests, "get", fake_get_factory(SAMPLE_HTML))
+
+    result = ourlads.read_starters_ourlads(["buf"])
+
+    expected = pd.DataFrame(
+        [
+            {"team": "buf", "position": "QB", "player": "Josh Allen", "status": "ACT"},
+            {"team": "buf", "position": "RB1", "player": "James Cook", "status": "ACT"},
+            {"team": "buf", "position": "RB2", "player": "Latavius Murray", "status": "ACT"},
+            {"team": "buf", "position": "WR1", "player": "Stefon Diggs", "status": "ACT"},
+            {"team": "buf", "position": "WR2", "player": "Gabriel Davis", "status": "ACT"},
+            {"team": "buf", "position": "WR3", "player": "Khalil Shakir", "status": "ACT"},
+            {"team": "buf", "position": "SLOT", "player": "Cole Beasley", "status": "ACT"},
+        ]
+    )
+
+    result = result.sort_values("position").reset_index(drop=True)
+    expected = expected.sort_values("position").reset_index(drop=True)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_read_starters_with_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ourlads.requests, "get", fake_get_factory(SAMPLE_HTML))
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        override_path = Path(tmp_dir) / "starters_override.csv"
+        override_df = pd.DataFrame(
+            [{"team": "buf", "position": "WR1", "player": "Override Receiver"}]
+        )
+        override_df.to_csv(override_path, index=False)
+
+        result = ourlads.read_starters_ourlads(["buf"], override_path=override_path)
+
+    wr1 = result[result["position"] == "WR1"]
+    assert len(wr1) == 1
+    assert wr1.iloc[0]["player"] == "Override Receiver"
+    assert wr1.iloc[0]["status"] == "ACT"
+
+    remaining_positions = set(result["position"])
+    assert {"QB", "RB1", "RB2", "WR2", "WR3", "SLOT"}.issubset(remaining_positions)


### PR DESCRIPTION
## Summary
- add a data source helper that scrapes Ourlads depth chart tables into starter slots
- expose the new reader at the package root
- cover the scraper and override handling with unit tests using fixture HTML

## Testing
- pytest tests/pybaseball/datasources/test_ourlads.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6599d35883279db2d163e73c3733