### PR TITLE
Add helpers for connecting to nflverse DuckDB dataset

### DIFF
--- a/docs/nflverse.md
+++ b/docs/nflverse.md
@@ -1,0 +1,35 @@
+# nflverse DuckDB integration
+
+Some environments that run `pybaseball` expose a shared DuckDB database at
+`/nflverse` containing supplemental play-by-play datasets.  The new
+`pybaseball.datasources.nflverse` module provides convenience helpers for
+connecting to that database without manually handling connection lifecycle
+management.
+
+## Opening a connection
+
+```python
+from pybaseball.datasources import connect_nflverse
+
+connection = connect_nflverse()
+try:
+    # connection is a duckdb.DuckDBPyConnection pointing at /nflverse
+    print(connection.execute("SHOW TABLES").fetchall())
+finally:
+    connection.close()
+```
+
+The helper validates that the `duckdb` dependency is available and that the
+`/nflverse` mount exists.  If either precondition is not met a clear
+`NFLverseConnectionError` is raised.
+
+For scripts that prefer the context-manager pattern you can use
+`nflverse_connection`, which automatically closes the connection:
+
+```python
+from pybaseball.datasources import nflverse_connection
+
+with nflverse_connection() as connection:
+    df = connection.execute("SELECT * FROM some_table LIMIT 5").df()
+```
+

--- a/pybaseball/__init__.py
+++ b/pybaseball/__init__.py
@@ -100,5 +100,6 @@ from .plotting import plot_teams
 from .plotting import plot_strike_zone
 from .datasources.fangraphs import (fg_batting_data, fg_pitching_data, fg_team_batting_data, fg_team_fielding_data,
                                     fg_team_pitching_data)
+from .datasources import connect_nflverse, nflverse_connection
 from .split_stats import get_splits
 from .version import __version__

--- a/pybaseball/datasources/__init__.py
+++ b/pybaseball/datasources/__init__.py
@@ -1,0 +1,15 @@
+"""Helper utilities for working with third-party data sources."""
+
+from .nflverse import (
+    DEFAULT_DATABASE_PATH as NFLVERSE_DATABASE_PATH,
+    NFLverseConnectionError,
+    connect as connect_nflverse,
+    nflverse_connection,
+)
+
+__all__ = [
+    "NFLVERSE_DATABASE_PATH",
+    "NFLverseConnectionError",
+    "connect_nflverse",
+    "nflverse_connection",
+]

--- a/pybaseball/datasources/nflverse.py
+++ b/pybaseball/datasources/nflverse.py
@@ -1,0 +1,114 @@
+"""Utilities for accessing the shared nflverse DuckDB database.
+
+The evaluation environment exposes a read-only DuckDB database mounted at
+``/nflverse``.  This module provides a small wrapper that validates the
+connection parameters and offers a convenient context manager for accessing
+that database.  When the database is unavailable, :class:`NFLverseConnectionError`
+provides a clear, actionable error message for the caller.
+"""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+try:  # pragma: no cover - exercised indirectly in tests
+    import duckdb
+except ModuleNotFoundError:  # pragma: no cover - handled explicitly
+    duckdb = None  # type: ignore[assignment]
+
+DEFAULT_DATABASE_PATH = "/nflverse"
+
+
+class NFLverseConnectionError(RuntimeError):
+    """Raised when a connection to the nflverse database cannot be established."""
+
+
+def _normalise_path(database_path: Optional[str]) -> str:
+    """Return a usable DuckDB database path.
+
+    ``None`` resolves to :data:`DEFAULT_DATABASE_PATH`.  Absolute paths are
+    preserved as-is while relative paths are expanded against the current
+    working directory.  ``""`` is rejected to surface misconfigurations.
+    """
+
+    if database_path is None:
+        path = DEFAULT_DATABASE_PATH
+    else:
+        path = os.fspath(database_path)
+
+    if not path:
+        raise ValueError("database_path must not be an empty string")
+
+    if path != ":memory:":
+        path = os.path.abspath(os.path.expanduser(path))
+
+    return path
+
+
+def connect(database_path: Optional[str] = None, *, read_only: bool = True):
+    """Return a DuckDB connection to the nflverse dataset.
+
+    Parameters
+    ----------
+    database_path:
+        A filesystem path to a DuckDB database.  ``None`` uses the standard
+        ``/nflverse`` mount provided in the execution environment.
+    read_only:
+        When ``True`` (the default) the connection is opened in read-only mode
+        to guard the shared dataset from accidental modification.
+
+    Raises
+    ------
+    NFLverseConnectionError
+        If the ``duckdb`` dependency is missing or the database cannot be
+        opened.
+    """
+
+    if duckdb is None:  # pragma: no cover - validated via tests
+        raise NFLverseConnectionError(
+            "The 'duckdb' package is required to connect to the nflverse dataset."
+            " Install it with `pip install duckdb`."
+        )
+
+    path = _normalise_path(database_path)
+
+    if read_only and path != ":memory:" and not os.path.exists(path):
+        raise NFLverseConnectionError(
+            f"The nflverse database was not found at '{path}'. "
+            "Make sure the dataset is available and the path is correct."
+        )
+
+    try:
+        return duckdb.connect(path, read_only=read_only)
+    except Exception as exc:  # pragma: no cover - defensive, exercised in tests
+        raise NFLverseConnectionError(
+            f"Unable to connect to the nflverse database at '{path}'."
+        ) from exc
+
+
+@contextmanager
+def nflverse_connection(
+    database_path: Optional[str] = None,
+    *,
+    read_only: bool = True,
+) -> Iterator["duckdb.DuckDBPyConnection"]:
+    """Context manager wrapper around :func:`connect`.
+
+    The connection is automatically closed once the context exits, even if an
+    exception is raised by the caller.
+    """
+
+    connection = connect(database_path=database_path, read_only=read_only)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+__all__ = [
+    "DEFAULT_DATABASE_PATH",
+    "NFLverseConnectionError",
+    "connect",
+    "nflverse_connection",
+]

--- a/tests/pybaseball/datasources/test_nflverse.py
+++ b/tests/pybaseball/datasources/test_nflverse.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from pybaseball.datasources import (
+    NFLVERSE_DATABASE_PATH,
+    NFLverseConnectionError,
+    connect_nflverse,
+    nflverse_connection,
+)
+
+
+def test_connect_requires_duckdb(monkeypatch):
+    monkeypatch.setattr("pybaseball.datasources.nflverse.duckdb", None, raising=False)
+    with pytest.raises(NFLverseConnectionError) as excinfo:
+        connect_nflverse(NFLVERSE_DATABASE_PATH)
+    assert "duckdb" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("read_only", [True, False])
+def test_connect_to_temp_database(read_only: bool):
+    duckdb = pytest.importorskip("duckdb")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.duckdb"
+        with duckdb.connect(str(db_path)) as conn:
+            conn.execute("CREATE TABLE IF NOT EXISTS example (id INTEGER)")
+            conn.execute("INSERT INTO example VALUES (1)")
+
+        conn = connect_nflverse(str(db_path), read_only=read_only)
+        try:
+            result = conn.execute("SELECT SUM(id) FROM example").fetchone()[0]
+            assert result == 1
+        finally:
+            conn.close()
+
+
+@pytest.mark.parametrize("context_manager", [False, True])
+def test_missing_database_raises(context_manager: bool):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        missing = Path(tmpdir) / "missing.duckdb"
+
+        if context_manager:
+            with pytest.raises(NFLverseConnectionError) as excinfo:
+                with nflverse_connection(str(missing)):
+                    pass
+        else:
+            with pytest.raises(NFLverseConnectionError) as excinfo:
+                connect_nflverse(str(missing))
+
+        message = str(excinfo.value)
+        assert "nflverse" in message
+        if "duckdb" in message and "required" in message:
+            pytest.skip("duckdb dependency unavailable in test environment")
+        assert os.fspath(missing) in message


### PR DESCRIPTION
## Summary
- add a datasources.nflverse module exposing connection helpers for the `/nflverse` DuckDB database
- re-export the helpers from the package root and document how to work with the shared dataset
- cover connection error handling with dedicated unit tests

## Testing
- pytest tests/pybaseball/datasources/test_nflverse.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f1dde3562483279cd6fb03bafcfb29