### PR TITLE
Add hybrid ice simulation helpers and example runner

### DIFF
--- a/EXAMPLES/hybrid_ice/Hybrid Ice V2 3 Plus.py
+++ b/EXAMPLES/hybrid_ice/Hybrid Ice V2 3 Plus.py
@@ -1,0 +1,55 @@
+"""Standalone Hybrid Ice v2.3+ simulation runner."""
+
+from __future__ import annotations
+
+from pybaseball.simulations.hybrid_ice import (
+    PlayerProfile,
+    format_results,
+    run_simulation,
+)
+
+
+def _sample_profiles() -> list[PlayerProfile]:
+    return [
+        PlayerProfile(
+            name="Riley 'Edge' Dawson",
+            edge_work=90,
+            transition_speed=94,
+            puck_control=89,
+            strength=82,
+            stamina=85,
+        ),
+        PlayerProfile(
+            name="Mika Snow",
+            edge_work=88,
+            transition_speed=91,
+            puck_control=86,
+            strength=78,
+            stamina=88,
+        ),
+        PlayerProfile(
+            name="Jordan Frost",
+            edge_work=84,
+            transition_speed=86,
+            puck_control=90,
+            strength=80,
+            stamina=83,
+        ),
+    ]
+
+
+def main() -> None:
+    profiles = _sample_profiles()
+    intensity = 1.12
+
+    results = run_simulation(profiles, intensity=intensity)
+
+    print("HYBRID ICE V2.3+ SIMULATION FORGE")
+    print("=" * 34)
+    print(f"Configured training intensity: {intensity}")
+    print()
+    print(format_results(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/EXAMPLES/hybrid_ice/run_hybrid_ice_simulation.py
+++ b/EXAMPLES/hybrid_ice/run_hybrid_ice_simulation.py
@@ -1,0 +1,38 @@
+"""Launch the Hybrid Ice v2.3+ simulation with graceful fallbacks."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    script_path = Path(__file__).with_name("Hybrid Ice V2 3 Plus.py")
+
+    print("\n\U0001F680 Running Hybrid Ice v2.3+ Simulation Forge...\n")
+
+    try:
+        subprocess.run([sys.executable, str(script_path)], check=True)
+    except FileNotFoundError:
+        print("⚠️ Unable to locate the Hybrid Ice simulation script.")
+        print("Please open 'Hybrid Ice V2 3 Plus.py' in your workspace and run it manually.")
+        return
+    except subprocess.CalledProcessError as exc:
+        print("⚠️ The simulation exited with a non-zero status code.")
+        print(f"Exit status: {exc.returncode}")
+        return
+    except Exception as exc:  # pragma: no cover - defensive catch-all for odd environments
+        print("⚠️ Unable to execute directly in this environment.\n")
+        print(
+            "Please open the 'Hybrid Ice V2 3 Plus' script in your Codex / Canvas workspace "
+            "and click ▶️ Run to execute locally."
+        )
+        print(f"\nError detail: {exc}")
+        return
+
+    print("\n✅ Simulation completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pybaseball/simulations/__init__.py
+++ b/pybaseball/simulations/__init__.py
@@ -1,0 +1,17 @@
+"""Simulation utilities for experimental training workflows."""
+
+from .hybrid_ice import (
+    PlayerProfile,
+    TrainingSessionResult,
+    evaluate_player,
+    format_results,
+    run_simulation,
+)
+
+__all__ = [
+    "PlayerProfile",
+    "TrainingSessionResult",
+    "evaluate_player",
+    "format_results",
+    "run_simulation",
+]

--- a/pybaseball/simulations/hybrid_ice.py
+++ b/pybaseball/simulations/hybrid_ice.py
@@ -1,0 +1,93 @@
+"""Hybrid Ice v2.3+ training simulation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class PlayerProfile:
+    """Attribute container describing an athlete in the hybrid program."""
+
+    name: str
+    edge_work: float
+    transition_speed: float
+    puck_control: float
+    strength: float
+    stamina: float
+
+
+@dataclass(frozen=True)
+class TrainingSessionResult:
+    """Outcome of the simulated training session."""
+
+    name: str
+    ice_index: float
+    fatigue_index: float
+    recommendation: str
+
+
+def _validate_intensity(intensity: float) -> None:
+    if intensity <= 0:
+        raise ValueError("intensity must be a positive value")
+
+
+def _weighted_attribute_sum(profile: PlayerProfile) -> float:
+    return (
+        profile.edge_work * 0.30
+        + profile.transition_speed * 0.25
+        + profile.puck_control * 0.20
+        + profile.strength * 0.15
+        + profile.stamina * 0.10
+    )
+
+
+def _fatigue_baseline(profile: PlayerProfile) -> float:
+    return (profile.strength * 0.40 + profile.stamina * 0.60) / 100.0
+
+
+def evaluate_player(profile: PlayerProfile, *, intensity: float = 1.0) -> TrainingSessionResult:
+    """Evaluate a single player for the requested training intensity."""
+
+    _validate_intensity(intensity)
+
+    ice_index = round(_weighted_attribute_sum(profile) * intensity, 2)
+    fatigue_index = round(max(0.0, intensity * 1.35 - _fatigue_baseline(profile)), 2)
+
+    if fatigue_index < 0.50:
+        recommendation = "Ready"
+    elif fatigue_index < 0.90:
+        recommendation = "Monitor"
+    else:
+        recommendation = "Recovery"
+
+    return TrainingSessionResult(
+        name=profile.name,
+        ice_index=ice_index,
+        fatigue_index=fatigue_index,
+        recommendation=recommendation,
+    )
+
+
+def run_simulation(
+    profiles: Iterable[PlayerProfile], *, intensity: float = 1.0
+) -> List[TrainingSessionResult]:
+    """Run the hybrid ice simulation over the provided profiles."""
+
+    _validate_intensity(intensity)
+
+    results = [evaluate_player(profile, intensity=intensity) for profile in profiles]
+    return sorted(results, key=lambda result: result.ice_index, reverse=True)
+
+
+def format_results(results: Iterable[TrainingSessionResult]) -> str:
+    """Format results as a simple text table."""
+
+    rows = ["Name                 Ice Idx  Fatigue  Recommendation"]
+    for result in results:
+        rows.append(
+            f"{result.name:<20}  {result.ice_index:>7.2f}   "
+            f"{result.fatigue_index:>6.2f}   {result.recommendation}"
+        )
+    return "\n".join(rows)

--- a/tests/pybaseball/test_hybrid_ice_simulation.py
+++ b/tests/pybaseball/test_hybrid_ice_simulation.py
@@ -1,0 +1,59 @@
+from pybaseball.simulations.hybrid_ice import (
+    PlayerProfile,
+    evaluate_player,
+    format_results,
+    run_simulation,
+)
+
+
+def _profiles():
+    return [
+        PlayerProfile(
+            name="Taylor Blades",
+            edge_work=90,
+            transition_speed=85,
+            puck_control=80,
+            strength=70,
+            stamina=75,
+        ),
+        PlayerProfile(
+            name="Casey Summit",
+            edge_work=86,
+            transition_speed=88,
+            puck_control=82,
+            strength=78,
+            stamina=80,
+        ),
+    ]
+
+
+def test_run_simulation_orders_by_ice_index():
+    profiles = _profiles()
+    results = run_simulation(profiles, intensity=1.0)
+
+    assert [result.name for result in results] == ["Casey Summit", "Taylor Blades"]
+    assert results[0].ice_index == 83.9
+    assert results[1].ice_index == 82.25
+
+
+def test_evaluate_player_recommendations():
+    profile = PlayerProfile(
+        name="Jordan Ice",
+        edge_work=88,
+        transition_speed=87,
+        puck_control=89,
+        strength=60,
+        stamina=58,
+    )
+
+    result = evaluate_player(profile, intensity=1.2)
+    assert result.recommendation == "Recovery"
+
+
+def test_format_results_creates_table():
+    results = run_simulation(_profiles(), intensity=1.0)
+    table = format_results(results)
+
+    assert "Name" in table.splitlines()[0]
+    assert "Casey Summit" in table
+    assert "Taylor Blades" in table


### PR DESCRIPTION
## Summary
- add a hybrid ice training simulation module with utilities for computing player indices
- provide an example runner script that mirrors the Hybrid Ice v2.3+ forge workflow
- cover the simulation logic with unit tests for ordering, recommendations, and formatting

## Testing
- pytest tests/pybaseball/test_hybrid_ice_simulation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125392ca1c8327b94d2d47b85f3575)